### PR TITLE
Feature: Extend/minize the modal to custom height

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,18 @@
+name: Publish Package to npmjs
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -70,3 +70,15 @@ function YourComponent() {
 | children | ReactNode | - | The children components | Kinda |
 | containerStyle | string | - | Styles for the modal sheet container | No |
 | noHandle | boolean | false | Hide the handle | No |
+| onGestureEnd | (e: PanGestureHandlerEventPayload) => void| - | Custom callback when the gesture ends | No |
+
+## Methods
+
+### useModalSheet
+
+| Name | Type | Description |
+| --- | --- | --- |
+| open | () => void | Open the modal sheet |
+| dismiss | () => void | Dismiss the modal sheet |
+| extend | (height?: number, disableSheetStack?: boolean) => void | Extend to custom height |
+| minimize | (height?: number, disableSheetStack?: boolean) => void | Minimize to custom height |

--- a/example/app/index.tsx
+++ b/example/app/index.tsx
@@ -1,14 +1,28 @@
 import { ModalSheet, useModalSheet } from "@corasan/modal-sheet";
-import { Button, StyleSheet, Text, View } from "react-native";
+import { Button, Dimensions, StyleSheet, Text, View } from "react-native";
+
+const HEIGHT = Dimensions.get("window").height;
 
 export default function App() {
-  const { open, dismiss } = useModalSheet();
+  const { open, dismiss, extend } = useModalSheet();
   return (
     <View style={styles.container}>
       <Button
         title="Open Modal"
         onPress={() => {
           open();
+        }}
+      />
+      <Button
+        title="Open Half"
+        onPress={() => {
+          extend(HEIGHT / 2, true);
+        }}
+      />
+      <Button
+        title="Open Minimum"
+        onPress={() => {
+          extend(HEIGHT - 150, true);
         }}
       />
       <ModalSheet>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corasan/modal-sheet",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Modal sheet component for React Native. Inspired by the native modal sheet in iOS.",
   "main": "src/index.ts",
   "scripts": {

--- a/src/ModalSheet.tsx
+++ b/src/ModalSheet.tsx
@@ -26,7 +26,6 @@ const HEIGHT = Dimensions.get("window").height;
 export interface ModalSheetProps {
   containerStyle?: StyleProp<AnimatedStyle<StyleProp<ViewStyle>>>;
   noHandle?: boolean;
-  minimizeHeight?: number;
   onGestureEnd?: (
     e: GestureStateChangeEvent<PanGestureHandlerEventPayload>,
   ) => void;

--- a/src/ModalSheet.tsx
+++ b/src/ModalSheet.tsx
@@ -15,6 +15,7 @@ import {
 } from "react-native-gesture-handler";
 import Animated, {
   AnimatedStyle,
+  runOnJS,
   useAnimatedStyle,
 } from "react-native-reanimated";
 
@@ -46,11 +47,16 @@ export const ModalSheet = ({
   ...props
 }: PropsWithChildren<ModalSheetProps>) => {
   const { translateY, minimize, open } = useInternalModalSheet();
+
   const gesture = Gesture.Pan()
     .onUpdate((e) => {
       translateY.value = e.absoluteY;
     })
     .onEnd((e) => {
+      if (props.onGestureEnd) {
+        runOnJS(props.onGestureEnd)(e);
+        return;
+      }
       if (e.translationY < 0) {
         open();
       } else {

--- a/src/ModalSheetProvider.tsx
+++ b/src/ModalSheetProvider.tsx
@@ -69,7 +69,7 @@ export const ModalSheetProvider = ({ children }: PropsWithChildren) => {
         opacity: interpolate(
           translateY.value,
           [HEIGHT, extendedHeight.value],
-          [0, 0.1],
+          [0, 0.4],
         ),
         zIndex: interpolate(
           translateY.value,
@@ -79,7 +79,7 @@ export const ModalSheetProvider = ({ children }: PropsWithChildren) => {
       };
     }
     return {
-      opacity: interpolate(translateY.value, [HEIGHT, 0], [0, 0.5]),
+      opacity: interpolate(translateY.value, [HEIGHT, 0], [0, 0.4]),
       zIndex: interpolate(translateY.value, [HEIGHT, 0], [-99, 999]),
     };
   });


### PR DESCRIPTION
## Features

- Added `extend(height?: number, disableStackSheet?: boolean) => void` to `useModalSheet`
- Added `minimize(height?: number, disableStackSheet?: boolean) => void` to `useModalSheet`
- Added `onGestureEnd(e: PanGestureHandlerEventPayload) => void` optional prop to `ModalSheet` component
- Updated example app
- Added github action to publish package on release published