### PR TITLE
Fix: Backdrop flicker

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,5 +82,5 @@ function YourComponent() {
 | --- | --- | --- |
 | open | () => void | Open the modal sheet |
 | dismiss | () => void | Dismiss the modal sheet |
-| extend | (height?: number, disableSheetStack?: boolean) => void | Extend to custom height |
+| expand | (height?: number, disableSheetStack?: boolean) => void | expand to custom height |
 | minimize | (height?: number, disableSheetStack?: boolean) => void | Minimize to custom height |

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ function YourComponent() {
 | containerStyle | string | - | Styles for the modal sheet container | No |
 | noHandle | boolean | false | Hide the handle | No |
 | minimumHeight | number | - | The minimum height the modal can be minized | No |
+| disableSheetStackEffect | boolean | - | Disable sheet stack effect | No |
 | onGestureEnd | (e: PanGestureHandlerEventPayload) => void| - | Custom callback when the gesture ends | No |
 
 ## Methods

--- a/example/app/index.tsx
+++ b/example/app/index.tsx
@@ -3,7 +3,7 @@ import { Button, Dimensions, StyleSheet, Text, View } from "react-native";
 
 const HEIGHT = Dimensions.get("window").height;
 export default function App() {
-  const { open, dismiss, extend } = useModalSheet();
+  const { open, dismiss, expand } = useModalSheet();
 
   return (
     <View style={styles.container}>
@@ -16,13 +16,13 @@ export default function App() {
       <Button
         title="Open Half"
         onPress={() => {
-          extend(HEIGHT / 2, true);
+          expand(HEIGHT / 2, true);
         }}
       />
       <Button
         title="Open Minimum"
         onPress={() => {
-          extend(HEIGHT - 150, true);
+          expand(HEIGHT - 150, true);
         }}
       />
       <ModalSheet

--- a/example/app/index.tsx
+++ b/example/app/index.tsx
@@ -2,7 +2,6 @@ import { ModalSheet, useModalSheet } from "@corasan/modal-sheet";
 import { Button, Dimensions, StyleSheet, Text, View } from "react-native";
 
 const HEIGHT = Dimensions.get("window").height;
-
 export default function App() {
   const { open, dismiss, extend } = useModalSheet();
 
@@ -26,7 +25,11 @@ export default function App() {
           extend(HEIGHT - 150, true);
         }}
       />
-      <ModalSheet minimumHeight={200}>
+      <ModalSheet
+        backdropColor="white"
+        backdropOpacity={0.5}
+        minimumHeight={200}
+      >
         <View style={{ flex: 1 }}>
           <View style={{ flexDirection: "row", justifyContent: "center" }}>
             <Text style={{ fontWeight: "500", fontSize: 18 }}>Modal Title</Text>

--- a/src/ModalSheet.tsx
+++ b/src/ModalSheet.tsx
@@ -44,7 +44,7 @@ export const useModalSheet = () => {
   return {
     open: context.open,
     dismiss: context.dismiss,
-    extend: context.extend,
+    expand: context.expand,
     minimize: context.minimize,
   };
 };

--- a/src/ModalSheet.tsx
+++ b/src/ModalSheet.tsx
@@ -33,6 +33,7 @@ export interface ModalSheetProps {
     e: GestureStateChangeEvent<PanGestureHandlerEventPayload>,
   ) => void;
   minimumHeight?: number;
+  disableSheetStackEffect?: boolean;
 }
 
 export const useModalSheet = () => {
@@ -73,6 +74,7 @@ export const ModalSheet = ({
     backdropColor: bckdropColor,
     setMinimumHeight,
     isAtMinimumHeight,
+    disableSheetStackEffect,
   } = useInternalModalSheet();
   const { top } = useSafeAreaInsets();
 
@@ -105,6 +107,7 @@ export const ModalSheet = ({
   }));
 
   useEffect(() => {
+    disableSheetStackEffect.value = !!props.disableSheetStackEffect;
     if (backdropColor && backdropColor !== "black") {
       bckdropColor.value = backdropColor;
     }
@@ -112,9 +115,14 @@ export const ModalSheet = ({
       bckdropOpacity.value = backdropOpacity;
     }
     if (minimumHeight) {
-      setMinimumHeight?.(minimumHeight);
+      setMinimumHeight(minimumHeight);
     }
-  }, [backdropOpacity, backdropOpacity, minimumHeight]);
+  }, [
+    backdropOpacity,
+    backdropOpacity,
+    minimumHeight,
+    props.disableSheetStackEffect,
+  ]);
 
   return (
     <Portal hostName="modalSheet">

--- a/src/ModalSheetProvider.tsx
+++ b/src/ModalSheetProvider.tsx
@@ -22,7 +22,7 @@ export const ModalSheetContext = createContext<{
   backdropOpacity: SharedValue<number>;
   open: () => void;
   dismiss: () => void;
-  extend: (height?: number, disableSheetStack?: boolean) => void;
+  expand: (height?: number, disableSheetStack?: boolean) => void;
   minimize: (height?: number, disableSheetStack?: boolean) => void;
   setMinimumHeight: (height: number) => void;
   isAtMinimumHeight: SharedValue<boolean>;
@@ -102,7 +102,7 @@ export const ModalSheetProvider = ({ children }: PropsWithChildren) => {
     translateY.value = withTiming(dismissValue.value);
   }, []);
 
-  const extend = useCallback((height?: number, disableSheetStack?: boolean) => {
+  const expand = useCallback((height?: number, disableSheetStack?: boolean) => {
     "worklet";
     if (disableSheetStack !== undefined) {
       disableSheetStackEffect.value = disableSheetStack;
@@ -135,7 +135,7 @@ export const ModalSheetProvider = ({ children }: PropsWithChildren) => {
         translateY,
         open,
         dismiss,
-        extend,
+        expand,
         minimize,
         backdropColor,
         backdropOpacity,

--- a/src/ModalSheetProvider.tsx
+++ b/src/ModalSheetProvider.tsx
@@ -112,10 +112,12 @@ export const ModalSheetProvider = ({ children }: PropsWithChildren) => {
   });
 
   const open = () => {
+    "worklet";
     disableSheetStackEffect.value = false;
-    translateY.value = withTiming(top + 20);
+    translateY.value = withSpring(top + 20, { mass: 0.35 });
   };
   const dismiss = () => {
+    "worklet";
     translateY.value = withTiming(dismissValue.value);
   };
 


### PR DESCRIPTION
## Features

- Added `disableSheetStackEffect` prop.

## Fixes

- Fixed the backdrop flickering when `expand` and `minimize` methods were used

## Breaking

- Renamed `extend` method to `minimize`