### PR TITLE
Fix: backdrop not disappearing when modal was dismissed by re-render

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@corasan/modal-sheet",
-  "version": "2.0.0-rc.15",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@corasan/modal-sheet",
-      "version": "2.0.0-rc.15",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@gorhom/portal": "^1.0.14",

--- a/src/Providers/ModalSheetInternalProvider.tsx
+++ b/src/Providers/ModalSheetInternalProvider.tsx
@@ -130,6 +130,13 @@ export function ModalSheetInternalProvider({ children }: PropsWithChildren) {
     })
   }
 
+  const reset = () => {
+    modalRefs.current = {}
+    drawerSheetRefs.current = {}
+    setModalStack([])
+    setDrawerSheetStack([])
+  }
+
   return (
     <ModalSheetInternalContext.Provider
       value={{
@@ -151,6 +158,7 @@ export function ModalSheetInternalProvider({ children }: PropsWithChildren) {
         childrenY,
         currentModal,
         previousModal,
+        reset,
       }}
     >
       <View style={styles.container}>

--- a/src/components/ModalSheetStack.tsx
+++ b/src/components/ModalSheetStack.tsx
@@ -29,12 +29,13 @@ export const ModalSheetStack = forwardRef<
       currentModal,
       modalStack,
       previousModal,
+      reset,
     } = useInternal()
     const {
       MODAL_SHEET_HEIGHT,
       SCREEN_HEIGHT,
       ANIMATE_BORDER_RADIUS,
-      DEFAULT_BORDER_RADIUS,
+      MODAL_SHEET_BORDER_RADIUS,
       TOP_INSET_HEIGHT,
       CHILDREN_Y_POSITION,
     } = useConstants()
@@ -59,7 +60,6 @@ export const ModalSheetStack = forwardRef<
         }
         const moveVal = e.absoluteY - prevGestureTouchY.value
         translateY.value = moveVal
-
         if (activeIndex.value === 0) {
           const y = interpolateClamp(
             moveVal,
@@ -68,7 +68,6 @@ export const ModalSheetStack = forwardRef<
           )
           updateY(y)
         }
-
         // Animate the previous modal based on current modal gesture
         if (previousModal.value) {
           const prev = previousModal.value
@@ -77,7 +76,7 @@ export const ModalSheetStack = forwardRef<
           prev.borderRadius.value = interpolateClamp(
             moveVal,
             [0, SCREEN_HEIGHT],
-            [ANIMATE_BORDER_RADIUS, DEFAULT_BORDER_RADIUS],
+            [ANIMATE_BORDER_RADIUS, MODAL_SHEET_BORDER_RADIUS],
           )
         }
       })
@@ -124,7 +123,7 @@ export const ModalSheetStack = forwardRef<
         if (modal) {
           modal.translateY.value = animateOpen(0)
           modal.scale.value = animateOpen(1)
-          modal.borderRadius.value = animateOpen(DEFAULT_BORDER_RADIUS)
+          modal.borderRadius.value = animateOpen(MODAL_SHEET_BORDER_RADIUS)
           modal.showBackdrop.value = animateOpen(1)
           let prevPrevModal = modalStack[activeIndex.value - 2]
           if (!prevModal) {
@@ -192,6 +191,10 @@ export const ModalSheetStack = forwardRef<
       // Register the modal with the context
       if (ref && 'current' in ref && ref.current) {
         registerModal(name, ref.current)
+      }
+
+      return () => {
+        reset()
       }
     }, [name, ref])
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,6 +92,7 @@ export interface ModalSheetContextBaseType {
   childrenY: SharedValue<number>
   currentModal: SharedValue<ModalSheetStackRef | null>
   previousModal: SharedValue<ModalSheetStackRef | null>
+  reset: () => void
 }
 
 export type ModalSheetInternalContextType = Omit<

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,20 +30,23 @@ export function animateClose(value: number) {
 
 export function useConstants() {
   const { top } = useSafeAreaInsets()
-  const MAX_HEIGHT = SCREEN_HEIGHT - Platform.select({ ios: top, default: 5 })
-  const MODAL_SHEET_HEIGHT = MAX_HEIGHT - 10
-  const DEFAULT_BORDER_RADIUS = Platform.select({ ios: 40, android: 28, default: 40 })
+  const androidTop = Platform.OS === 'android' && top === 0 ? 24 : top
+  const topPadding = Platform.select({ ios: top, android: androidTop, default: 24 })
+  const MAX_HEIGHT = SCREEN_HEIGHT - topPadding
+  const MODAL_SHEET_HEIGHT = MAX_HEIGHT - 16
+  const MODAL_SHEET_BORDER_RADIUS = Platform.select({ ios: 40, android: 28, default: 40 })
   const ANIMATE_BORDER_RADIUS = Platform.select({ ios: 24, android: 20, default: 40 })
-  const TOP_INSET_HEIGHT = top
-  const CHILDREN_Y_POSITION = top - 10
+  const TOP_INSET_HEIGHT = topPadding
+  const CHILDREN_Y_POSITION = topPadding - 10
+  const SWIPE_VELOCITY_THRESHOLD = 1500
 
   return {
     MAX_HEIGHT,
     MODAL_SHEET_HEIGHT,
     SCREEN_HEIGHT,
     CHILDREN_Y_POSITION,
-    SWIPE_VELOCITY_THRESHOLD: 1500,
-    DEFAULT_BORDER_RADIUS,
+    SWIPE_VELOCITY_THRESHOLD,
+    MODAL_SHEET_BORDER_RADIUS,
     ANIMATE_BORDER_RADIUS,
     TOP_INSET_HEIGHT,
   }


### PR DESCRIPTION
## Fixes

- Fixed issue that cause the modal to disappear but the backdrop was still showing, causing app to become unusable
